### PR TITLE
update wavecal order2 poly method to not depend on offset

### DIFF
--- a/pastasoss/wavecal.py
+++ b/pastasoss/wavecal.py
@@ -277,7 +277,9 @@ def wavecal_model_order2_poly(x, pwcpos, wavecal_meta: NIRISS_GR700XD_WAVECAL_ME
     x_scaled = x_scaler(x)
 
     # offset
-    offset = np.ones_like(x) * (pwcpos - PWCPOS_CMD)
+    # offset = np.ones_like(x) * (pwcpos - PWCPOS_CMD)
+    # this will need to get changed later...
+    offset = np.ones_like(x) * pwcpos
     offset_scaled = pwcpos_offset_scaler(offset)
 
     # polynomial features


### PR DESCRIPTION
Forgot to update the order2 wavecal poly function to reflect the change in how pwcpos is normalize with respect to the pupil wheel tolerance range rather than the offer (i.e, NEW: PWCPOS_CMD +/- PWCPOS tolerance, older offset = PWCPOS +/-  PWCPOS_CMD). If this is not fix, it return the wrong values not in the expected wavelength range. This should also be turned into a test at some point and will make open and issues to keep track of this. 