### PR TITLE
pypi publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,17 +1,15 @@
-name: Publish to PyPI
+name: build
 
 on:
   release:
     types: [released]
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  publish:
-    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+  build:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      test: false
-      build_platform_wheels: false # Set to true if your package contains a C extension
+      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
     secrets:
-      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
-      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}
+      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}


### PR DESCRIPTION
The current publish-to-pypy.html crashes when creating a new release triggering a deprecation error. Mees Fix provided replacement text to update the file with. 

