### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Change log adopted from the transitspectroscopy package by Nestor Espinoza. 
 
-## [0.1.0] - 2023-05-03
-### Added
-- Developers: Tyler Baines and Mees Fix
-- Basic setup and installation files. 
-- First version of package under revision and under going testing.
-- Updating code and updating data files in package. 
 
-## [1.0.0] - Package first released
+# [1.2.1] - 2024-12-16
 ### Added
-- Developers: Tyler Baines and Mees Fix
-- Performed first release of the python package on github 
-- have few people test including myself passed
-- 
-
-# [1.1.0] - 2023-08-29
-### Added
-- Updating packing to include new wavelength calibration reference file that 
-are not apart of the JWST pipeline currently. 
-
-
-# [1.1.0] - 2023-09-08
-### Added
-- modified some of the archeitecture for return outputs of trace and wavelength
-predictions.
-- refactoring the package to be in a more maintable state is being
-planned but not implemented in this version (should be v1.1 now)
-- need to push changes to ST main repo thus tag up with Mees again. 
-
-# [1.1.0] - 2023-09-20
-### Added
-- updated demo notebook to include having to download a soss dataset from PID 1512
-- finished integration of wavecal model and tested extensively in my dev branch
-- updated the order 2 reference trace model which now extend from 600 to 1750
-- readme has been update with some changes
+- removed unused .yml files and requirement.txt
+- update pyproject.toml file with required pacakage as we as numpy support below version 2.0 to address open issue #13. 
 
 # [1.2.0] - 2024-04-02
 ### Added
@@ -54,9 +25,38 @@ so 3.10 will now be the the minimum version.
 - also making additional to changes to some test and removing the duplicate
 test folder that was present. 
 
-
-
-# [1.2.1] - 2024-12-16
+# [1.1.0] - 2023-09-20
 ### Added
-- removed unused .yml files and requirement.txt
-- update pyproject.toml file with required pacakage as we as numpy support below version 2.0 to address open issue #13. 
+- updated demo notebook to include having to download a soss dataset from PID 1512
+- finished integration of wavecal model and tested extensively in my dev branch
+- updated the order 2 reference trace model which now extend from 600 to 1750
+- readme has been update with some changes
+
+
+# [1.1.0] - 2023-09-08
+### Added
+- modified some of the archeitecture for return outputs of trace and wavelength
+predictions.
+- refactoring the package to be in a more maintable state is being
+planned but not implemented in this version (should be v1.1 now)
+- need to push changes to ST main repo thus tag up with Mees again. 
+
+
+# [1.1.0] - 2023-08-29
+### Added
+- Updating packing to include new wavelength calibration reference file that 
+are not apart of the JWST pipeline currently. 
+
+
+## [1.0.0] - Package first released
+### Added
+- Developers: Tyler Baines and Mees Fix
+- Performed first release of the python package on github 
+- have few people test including myself passed
+
+## [0.1.0] - 2023-05-03
+### Added
+- Developers: Tyler Baines and Mees Fix
+- Basic setup and installation files. 
+- First version of package under revision and under going testing.
+- Updating code and updating data files in package. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Change log adopted from the transitspectroscopy package by Nestor Espinoza. 
 
 
+# [1.2.2] - 2024-02-18
+### Added
+- update pyproject.toml file with required pacakage to support scipy>=1.8.0 to address issue #13 to resolve dependency conflicts. 
+
+
 # [1.2.1] - 2024-12-16
 ### Added
 - removed unused .yml files and requirement.txt

--- a/pastasoss/__init__.py
+++ b/pastasoss/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 from .soss_traces import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "numpy<2.0.0",
     "matplotlib>=3.6.2",
     "pytest>=7.2.0",
-    "scipy>=1.10.1",
+    "scipy>=1.8.0",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Updating package dependencies as address in issue #13.  Numpy and Scipy requirements have been change at the request of users. In this PR, scipy was changes from 1.10.x to 1.8.0 to support the minimum support version for python 3.10. 