### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/pastasoss/soss_traces.py
+++ b/pastasoss/soss_traces.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 import numpy as np
 from scipy.interpolate import interp1d
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from pastasoss.wavecal import get_wavecal_meta_for_spectral_order
 from pastasoss.wavecal import get_wavelengths
@@ -23,11 +23,11 @@ REFERENCE_TRACE_FILES = {
 }
 
 REFERENCE_WAVECAL_MODELS = {
-    "order1": resource_filename(
-        __name__, "data/jwst_niriss_gr700xd_wavelength_model_order1.json"
+    "order1": str(files(__package__).joinpath(
+        "data/jwst_niriss_gr700xd_wavelength_model_order1.json")
     ),
-    "order2": resource_filename(
-        __name__, "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json"
+    "order2": str(files(__package__).joinpath(
+        "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json")
     ),
 }
 
@@ -123,7 +123,7 @@ def get_reference_trace(
     --------
     >>> x, y, origin = get_reference_traces_positions('ref_filename.txt')
     """
-    filepath = resource_filename(__name__, f"data/{file}")
+    filepath = files(__package__).joinpath(f"data/{file}")
     traces = np.loadtxt(filepath)
     origin = traces[0]
     x = traces[1:, 0]

--- a/pastasoss/wavecal.py
+++ b/pastasoss/wavecal.py
@@ -18,10 +18,10 @@ PWCPOS_CMD = 245.76
 # TODO: order 3 currently unsupport ATM. Will be support in the future: TBD
 REFERENCE_WAVECAL_MODELS = {
     "order1": str(files(__package__).joinpath(
-        "data/jwst_niriss_gr700xd_wavelength_model_order1.json"
+        "data/jwst_niriss_gr700xd_wavelength_model_order1.json")
     ),
     "order2": str(files(__package__).joinpath(
-        "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json"
+        "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json")
     ),
 }
 

--- a/pastasoss/wavecal.py
+++ b/pastasoss/wavecal.py
@@ -10,18 +10,18 @@ from typing import Any, Dict
 
 import numpy as np
 import numpy.typing as npt
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 # explicitly defining the commanded position here as well (this is temp)
 PWCPOS_CMD = 245.76
 
 # TODO: order 3 currently unsupport ATM. Will be support in the future: TBD
 REFERENCE_WAVECAL_MODELS = {
-    "order1": resource_filename(
-        __name__, "data/jwst_niriss_gr700xd_wavelength_model_order1.json"
+    "order1": str(files(__package__).joinpath(
+        "data/jwst_niriss_gr700xd_wavelength_model_order1.json"
     ),
-    "order2": resource_filename(
-        __name__, "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json"
+    "order2": str(files(__package__).joinpath(
+        "data/jwst_niriss_gr700xd_wavelength_model_order2_002.json"
     ),
 }
 


### PR DESCRIPTION
This resolves a deprecation warning related to pkg_resources.resource_filename, which is slated for removal in late 2025. All uses were replaced with the modern importlib.resources.files() API. This change requires Python 3.9+.

In particular, the previous warning message was:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```