### PR TITLE
Update numpy dependency to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Tyler Baines", email = "tbaines@stsci.edu" }]
 requires-python = ">=3.10"
 dependencies = [
     "jupyter>=1.0.0",
-    "numpy<2.0.0",
+    "numpy",
     "matplotlib>=3.6.2",
     "pytest>=7.2.0",
     "scipy>=1.8.0",


### PR DESCRIPTION
I ran a suite of local testing with Python 3.10-3.14 with the `numpy<2` limit removed, and the pytest suite passed for all setups (numpy resolved to numpy-2.4.4 for Python>=3.11 and numpy-2.2.6 for Python 3.10). I'd ask you please remove that limit as numpy 2.0.0 was released way back on Jun 15, 2024 and pinning numpy<2 is going to cause issues with some other packages sooner or later